### PR TITLE
Allow zero density and add validation tests

### DIFF
--- a/src/voronoimaker/cli.py
+++ b/src/voronoimaker/cli.py
@@ -41,6 +41,14 @@ def _ensure_non_negative(name: str, value: float) -> None:
         raise typer.BadParameter(f"{name} must be zero or greater.", param_hint=name)
 
 
+def _ensure_at_most(name: str, value: float, maximum: float, *, message: str | None = None) -> None:
+    """Ensure ``value`` does not exceed ``maximum``."""
+
+    if value > maximum:
+        error_message = message or f"{name} must be {maximum} or less."
+        raise typer.BadParameter(error_message, param_hint=name)
+
+
 def _ensure_positive_int(name: str, value: int) -> None:
     """Ensure ``value`` is a positive integer."""
 
@@ -61,7 +69,13 @@ def _validate_parameters(
     """
 
     _ensure_positive("shell_thickness", shell_thickness)
-    _ensure_positive("density", density)
+    _ensure_non_negative("density", density)
+    _ensure_at_most(
+        "density",
+        density,
+        1.0,
+        message="density must be between 0 and 1 (inclusive).",
+    )
     _ensure_non_negative("relief_depth", relief_depth)
     _ensure_positive_int("seeds", seeds)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_SRC_PATH = _PROJECT_ROOT / "src"
+if str(_SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(_SRC_PATH))

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,0 +1,25 @@
+import pytest
+from typer import BadParameter
+
+from voronoimaker.cli import Mode, _validate_parameters
+
+
+def test_density_zero_allowed() -> None:
+    _validate_parameters(Mode.SURFACE, shell_thickness=1.0, density=0.0, relief_depth=1.0, seeds=1)
+
+
+def test_density_one_allowed() -> None:
+    _validate_parameters(Mode.SURFACE, shell_thickness=1.0, density=1.0, relief_depth=1.0, seeds=1)
+
+
+def test_density_above_one_rejected() -> None:
+    with pytest.raises(BadParameter) as exc_info:
+        _validate_parameters(
+            Mode.SURFACE,
+            shell_thickness=1.0,
+            density=1.1,
+            relief_depth=1.0,
+            seeds=1,
+        )
+
+    assert "between 0 and 1" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- enforce density values within the inclusive 0–1 range while keeping other parameter checks intact
- cover valid boundary and out-of-range density values with new CLI validation tests
- ensure tests can import the package by adding a test configuration module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd913dcfd48322bd120c0c8b0d038f