### PR TITLE
Parse JSON seeds option for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Main dependencies:
 ## Command line usage (CLI)
 
 ```bash
-poetry run voronoimaker run input.stl output.stl --mode radial --shell-thickness 1.2 --density 0.6 --relief-depth 0.6
+poetry run voronoimaker run input.stl output.stl \
+  --mode multicenter --shell-thickness 1.2 --density 0.6 --relief-depth 0.6 \
+  --seeds '[[0,0,0],[10,5,2]]'
 ```
 
 Key options:
@@ -60,7 +62,7 @@ Key options:
 - `--shell-thickness`: skin thickness in mm (e.g. `1.2`)
 - `--density`: relative density of Voronoi cells (0–1)
 - `--relief-depth`: carving/perforation depth in mm
-- `--seeds`: JSON list of centroids for multicenter mode
+- `--seeds`: JSON array of `[x, y, z]` centroid coordinates for multicenter mode (e.g. `'[[0,0,0],[10,5,2]]'`)
 
 ---
 

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,15 +1,27 @@
 import pytest
 from typer import BadParameter
 
-from voronoimaker.cli import Mode, _validate_parameters
+from voronoimaker.cli import Mode, _parse_seeds, _validate_parameters
 
 
 def test_density_zero_allowed() -> None:
-    _validate_parameters(Mode.SURFACE, shell_thickness=1.0, density=0.0, relief_depth=1.0, seeds=1)
+    _validate_parameters(
+        Mode.SURFACE,
+        shell_thickness=1.0,
+        density=0.0,
+        relief_depth=1.0,
+        seeds=[],
+    )
 
 
 def test_density_one_allowed() -> None:
-    _validate_parameters(Mode.SURFACE, shell_thickness=1.0, density=1.0, relief_depth=1.0, seeds=1)
+    _validate_parameters(
+        Mode.SURFACE,
+        shell_thickness=1.0,
+        density=1.0,
+        relief_depth=1.0,
+        seeds=[(1.0, 2.0, 3.0)],
+    )
 
 
 def test_density_above_one_rejected() -> None:
@@ -19,7 +31,47 @@ def test_density_above_one_rejected() -> None:
             shell_thickness=1.0,
             density=1.1,
             relief_depth=1.0,
-            seeds=1,
+            seeds=[(1.0, 2.0, 3.0)],
         )
 
     assert "between 0 and 1" in str(exc_info.value)
+
+
+def test_multicenter_requires_at_least_one_seed() -> None:
+    with pytest.raises(BadParameter):
+        _validate_parameters(
+            Mode.MULTICENTER,
+            shell_thickness=1.0,
+            density=0.5,
+            relief_depth=1.0,
+            seeds=[],
+        )
+
+
+def test_parse_seeds_valid_json() -> None:
+    assert _parse_seeds("[[0, 0, 0], [1.5, 2.5, 3.5]]") == [
+        (0.0, 0.0, 0.0),
+        (1.5, 2.5, 3.5),
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ("", ""),
+        ("[]", ""),
+        ("not json", "valid JSON"),
+        ("{}", "array"),
+        ("[1, 2]", "three"),
+        ("[[1, 2, \"a\"]]", "numbers"),
+    ],
+)
+def test_parse_seeds_invalid_inputs(payload: str, message: str) -> None:
+    if payload in {"", "[]"}:
+        assert _parse_seeds(payload) == []
+        return
+
+    with pytest.raises(BadParameter) as exc_info:
+        _parse_seeds(payload)
+
+    assert message in str(exc_info.value)


### PR DESCRIPTION
## Summary
- parse the `--seeds` option as JSON centroids and validate multicenter usage
- show structured seed output in the placeholder pipeline
- document the working JSON example and extend CLI validation tests

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd93ece90883228b7edf12e6e94afc