### PR TITLE
Create docs directory with project documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture Overview
+
+Voronoi Maker is structured as a Python project that exposes both a command-line interface (CLI) and a desktop GUI shell. The core Voronoi processing engine is still under construction, so the current architecture emphasises modular frontends that can be wired into the forthcoming geometry pipeline.
+
+## Source layout
+
+```
+src/
+  voronoimaker/
+    __init__.py
+    cli.py
+ui/
+  main.py
+```
+
+- **`src/voronoimaker`** hosts the distributable Python package. It is configured with a `src` layout via `pyproject.toml` so that tooling (Poetry, test runners) imports the package consistently.
+- **`cli.py`** defines the Typer-based entry point published as the `voronoimaker` console script. Today it performs argument validation and dispatches to a placeholder pipeline. When the geometry engine is ready, it will orchestrate preprocessing, Voronoi carving, and STL export.
+- **`ui/main.py`** contains the PySide6 application bootstrap and widget definitions. The GUI is currently a skeleton designed to surface parameter controls, drag-and-drop for STL files, logging, and a reserved area for the upcoming 3D preview.
+
+## Command-line flow
+
+1. Users invoke `voronoimaker run` with an input STL, optional output path, processing mode, and numeric parameters.
+2. The CLI derives the destination path when `--output` is omitted (`_default_output_path`).
+3. Seeds for multicenter mode are parsed from JSON, validated, and returned as coordinate triples.
+4. `_validate_parameters` enforces numeric ranges and mode-specific rules (e.g., relief depth cannot be zero in surface mode, multicenter mode requires at least one seed).
+5. A placeholder `_run_placeholder_pipeline` echoes the configuration; this will eventually delegate to the real Voronoi engine.
+
+The CLI module is intentionally self-contained and does not yet import geometry libraries. This keeps the interface stable while the backend evolves.
+
+## Desktop application flow
+
+1. `ui/main.py` boots a `QApplication`, constructs the `MainWindow`, and enters the Qt event loop.
+2. `MainWindow` assembles three major regions:
+   - A **parameter sidebar** with `FloatParameterControl` widgets that pair sliders with spin boxes for responsive numeric tuning.
+   - A **preview placeholder** (`PreviewPlaceholder`) that will host vedo/pyvista integrations. Its `update_scene` hook is ready for future mesh rendering code.
+   - A **log console** (`LogConsole`) that integrates with Python's `logging` module through a lightweight `_QtLogHandler`.
+3. File input actions are exposed via menu entries, toolbar buttons, and drag-and-drop handlers. They currently record file selections in the console but defer processing until the backend is complete.
+4. The “Apply Voronoi” action exists in the UI state machine but remains disabled until the geometry pipeline is implemented.
+
+## Planned backend integration
+
+The eventual Voronoi pipeline will likely introduce additional modules to:
+
+- Load and normalise STL meshes (via `trimesh` or `pyvista`).
+- Generate Voronoi seeds (surface, radial, multicenter) and compute cell boundaries.
+- Perform boolean operations to carve Voronoi cavities while respecting shell thickness targets.
+- Export validated STL geometry ready for slicing.
+
+These capabilities will live alongside the existing package and be consumed by both the CLI and GUI. The separation between frontends (CLI/UI) and the yet-to-be-built geometry core keeps the architecture flexible: new delivery channels (e.g., FastAPI backend) can reuse the same processing layer with minimal duplication.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,50 @@
+# Roadmap
+
+This roadmap highlights the major workstreams required to deliver a feature-complete Voronoi Maker across CLI, desktop, and future web experiences. Milestones are grouped by theme and ordered roughly by dependency.
+
+## Geometry and processing engine
+
+- [ ] Implement Voronoi cell generation across surface, radial, and multicenter modes.
+- [ ] Add configurable seed generators (auto radial sampling, manual JSON ingestion, adaptive density).
+- [ ] Perform boolean carving and mesh cleanup to inscribe Voronoi cavities while preserving shell integrity.
+- [ ] Provide shell offsetting algorithms that maintain user-defined thickness.
+- [ ] Export validated STL files and add regression tests to ensure slicer compatibility.
+
+## Command-line interface
+
+- [ ] Replace `_run_placeholder_pipeline` with calls into the real processing engine.
+- [ ] Emit progress and metrics (timings, face counts) for completed jobs.
+- [ ] Support batch processing of multiple input files.
+- [ ] Surface presets and configuration files for repeatable parameter sets.
+
+## Desktop application (PySide6)
+
+- [ ] Wire the Apply Voronoi button to the processing engine and stream status updates to the log console.
+- [ ] Integrate vedo/pyvista (or Qt3D) to render interactive previews with orbit, pan, zoom, and before/after toggles.
+- [ ] Implement drag-and-drop queues so multiple meshes can be processed sequentially.
+- [ ] Allow saving/exporting the processed mesh directly from the GUI.
+- [ ] Persist user preferences (recent files, default parameters).
+
+## Testing and quality
+
+- [ ] Expand unit tests to cover CLI validation, geometry utilities, and UI logic (via Qt test harnesses).
+- [ ] Add golden-model tests with sample STL fixtures to catch regressions.
+- [ ] Integrate continuous integration workflows (linting, tests, packaging).
+
+## Distribution and platform support
+
+- [ ] Package signed binaries for macOS (arm64/x86_64) using PyInstaller or Briefcase.
+- [ ] Provide Windows and Linux builds with consistent functionality.
+- [ ] Publish the Python package on PyPI once the API stabilises.
+
+## Web and backend expansion
+
+- [ ] Develop a FastAPI backend that exposes Voronoi processing as a REST job API.
+- [ ] Build a lightweight web frontend (React/Svelte) with STL upload, parameter controls, and download links.
+- [ ] Investigate WebAssembly/offloading strategies for client-side previews.
+
+## Community and documentation
+
+- [ ] Capture before/after showcases and animated demos for the README and website.
+- [ ] Document developer onboarding, coding standards, and contribution guidelines.
+- [ ] Maintain an up-to-date changelog and release notes.

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -1,0 +1,70 @@
+# User Stories
+
+## Legend
+- **Done** – Implemented and working today.
+- **WIP** – Partially implemented, placeholder-backed, or blocked by dependencies.
+- **TODO** – Planned but not yet started.
+- **Proposed** – Suggested ideas pending triage.
+
+## Command-line workflow
+
+### CLI generates Voronoi jobs — **Status: WIP**
+As a command-line user, I want to run `voronoimaker run` with my preferred mode and parameters so that I can generate a processed STL on demand. The Typer-based CLI exposes arguments, validates parameters, derives output filenames, and invokes a placeholder pipeline. Actual Voronoi processing is still under development.
+
+### CLI validates numeric parameters — **Status: Done**
+As a command-line user, I want immediate feedback when I provide invalid numeric parameters so that I can correct mistakes before processing. The CLI performs range checks, mode-specific guards, and emits actionable error messages.
+
+### CLI auto-derives output filenames — **Status: Done**
+As a command-line user, I want the tool to pick a sensible destination when I omit `--output` so that I can iterate quickly. The CLI derives a `_voronoi` filename next to the source mesh and creates parent directories on demand.
+
+### Multicenter seed ingestion accepts JSON payloads — **Status: TODO**
+As a multicenter user, I want to pass an explicit list of centroid coordinates so that the Voronoi regions follow my chosen anchors. The CLI currently accepts only numeric counts and validates structure, but the downstream pipeline ignores seed data until the geometry engine arrives.
+
+## Desktop application
+
+### PySide6 main window exposes controls — **Status: Done**
+As a desktop user, I want a main window with grouped parameter sliders, mode selectors, and room for previews so that tuning settings feels approachable. The `MainWindow` assembles parameter widgets, a mode selector, and a split layout that reserves space for preview and logs.
+
+### STL selection and drag & drop queue files — **Status: WIP**
+As a desktop user, I want to add STL files via buttons or drag-and-drop so that I can start processing without leaving the GUI. The UI logs file selections but still routes processing through stubs.
+
+### 3D preview renders interactive meshes — **Status: WIP**
+As a desktop user, I want to inspect meshes in-app so that I can verify the Voronoi effect before exporting. A placeholder frame and update hooks exist, yet no rendering backend is wired in; integrating vedo/pyvista remains open.
+
+### Apply Voronoi action runs the pipeline — **Status: TODO**
+As a desktop user, I want the “Apply Voronoi” button to generate a new mesh so that the GUI completes the workflow. The button is present but disabled with a tooltip explaining that the pipeline is not ready.
+
+### Embedded log console captures application messages — **Status: Done**
+As a desktop user, I want to see progress and warnings in-app so that I know what the tool is doing. The log console registers a Qt-aware logging handler, auto-scrolls new messages, and is initialized with the window.
+
+## Voronoi processing pipeline
+
+### Boolean Voronoi carving on meshes — **Status: TODO**
+As a mesh-processing engineer, I want robust boolean operations that inscribe Voronoi cells onto STL surfaces so that the output geometry reflects the selected pattern. The CLI and GUI are waiting on this core functionality.
+
+### Shell offset control matches requested thickness — **Status: TODO**
+As a maker focused on printability, I want the Voronoi skin to maintain a reliable shell thickness so that the final part is structurally sound. This remains a roadmap item with no implementation in the current codebase.
+
+### Export produces printer-ready STL files — **Status: TODO**
+As a user preparing prints, I want the tool to emit valid STL files directly so that I can slice them immediately. Reliable export is still on the roadmap.
+
+## Distribution and platform
+
+### Packaged macOS application — **Status: TODO**
+As a macOS user, I want a signed binary I can launch without a Python environment so that sharing the tool is easy. Build instructions mention PyInstaller packaging, but producing a universal binary is still planned.
+
+## Web and backend expansion
+
+### FastAPI backend with web client — **Status: TODO**
+As a remote user, I want to run Voronoi processing from a web interface so that I can use the tool without installing desktop software. A FastAPI backend and web frontend are future milestones with no supporting code yet.
+
+## Proposed ideas awaiting triage
+
+### Rich 3D viewport interactions — **Status: Proposed**
+As a power user, I want to rotate, zoom, and compare original versus voronized meshes inside the UI so that I can judge quality visually. These capabilities are described as part of the recommended frontend but have no implementation yet.
+
+### One-click STL export from the UI — **Status: Proposed**
+As a desktop user, I want to export the processed mesh with a single action so that I can quickly move to slicing. This convenience feature is suggested alongside other UI ideas and still needs design and implementation discussions.
+
+### Showcase before/after screenshots — **Status: Proposed**
+As a prospective user, I want to see example results so that I understand the project’s value. The README promises upcoming screenshots, indicating that collecting and publishing them is still on the wish list.


### PR DESCRIPTION
## Summary
- add a docs folder housing high-level project documentation
- document current user stories with statuses drawn from existing functionality
- capture the present architecture layout and outline the forward-looking roadmap

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_b_68cd94cb59a08322bd026413fa893ae5