### PR TITLE
Add STL loading helper and tests

### DIFF
--- a/src/voronoimaker/__init__.py
+++ b/src/voronoimaker/__init__.py
@@ -1,0 +1,5 @@
+"""Public package interface for Voronoi Maker."""
+
+from .io import load_stl
+
+__all__ = ["load_stl"]

--- a/src/voronoimaker/cli.py
+++ b/src/voronoimaker/cli.py
@@ -9,6 +9,8 @@ from typing import Optional, Sequence
 
 import typer
 
+from .io import load_stl
+
 
 class Mode(str, Enum):
     """Supported processing modes for Voronoi generation."""
@@ -139,6 +141,7 @@ def _run_placeholder_pipeline(
     density: float,
     relief_depth: float,
     seeds: Sequence[SeedPoint],
+    mesh: "trimesh.Trimesh",
 ) -> None:
     """Placeholder pipeline execution.
 
@@ -148,6 +151,8 @@ def _run_placeholder_pipeline(
     typer.echo("Voronoi Maker (placeholder)")
     typer.echo(f"  Input:           {input_path}")
     typer.echo(f"  Output:          {output_path}")
+    typer.echo(f"  Mesh vertices:   {len(mesh.vertices)}")
+    typer.echo(f"  Mesh faces:      {len(mesh.faces)}")
     typer.echo(f"  Mode:            {mode.value}")
     typer.echo(f"  Surface skin:    {shell_thickness}")
     typer.echo(f"  Density:         {density}")
@@ -215,6 +220,11 @@ def run(
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
+    try:
+        mesh = load_stl(input)
+    except (FileNotFoundError, ValueError) as exc:
+        raise typer.BadParameter(str(exc), param_hint="input") from exc
+
     _run_placeholder_pipeline(
         input_path=input,
         output_path=output_path,
@@ -223,5 +233,6 @@ def run(
         density=density,
         relief_depth=relief_depth,
         seeds=seeds,
+        mesh=mesh,
     )
     # TODO: Replace placeholder execution with the actual Voronoi pipeline.

--- a/src/voronoimaker/io.py
+++ b/src/voronoimaker/io.py
@@ -1,0 +1,51 @@
+"""Input/output helpers for Voronoi Maker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import trimesh
+
+
+def load_stl(path: Path) -> trimesh.Trimesh:
+    """Load an STL mesh from ``path``.
+
+    Args:
+        path: Location of the STL file on disk.
+
+    Returns:
+        A :class:`trimesh.Trimesh` instance containing the parsed mesh.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist or is not a file.
+        ValueError: If the path is not an STL file or could not be parsed.
+    """
+
+    file_path = Path(path)
+
+    if not file_path.exists() or not file_path.is_file():
+        raise FileNotFoundError(f"STL file not found: {file_path}")
+
+    if file_path.suffix.lower() != ".stl":
+        raise ValueError(
+            f"Unsupported mesh format for '{file_path.name}'. Expected an STL file."
+        )
+
+    try:
+        mesh = trimesh.load(file_path, file_type="stl", force="mesh")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"STL file not found: {file_path}") from exc
+    except ValueError as exc:
+        raise ValueError(f"Failed to parse STL file '{file_path}': {exc}") from exc
+    except Exception as exc:  # pragma: no cover - defensive guard for trimesh loaders
+        raise ValueError(f"Failed to parse STL file '{file_path}': {exc}") from exc
+
+    if not isinstance(mesh, trimesh.Trimesh):
+        raise ValueError(
+            f"Failed to load STL file '{file_path}': unsupported mesh contents."
+        )
+
+    if mesh.is_empty:
+        raise ValueError(f"STL file '{file_path}' does not contain any geometry.")
+
+    return mesh

--- a/tests/fixtures/triangle.stl
+++ b/tests/fixtures/triangle.stl
@@ -1,0 +1,9 @@
+solid triangle
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 0
+      vertex 0 1 0
+    endloop
+  endfacet
+endsolid triangle

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+import trimesh
+
+from voronoimaker.io import load_stl
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def test_load_stl_success() -> None:
+    mesh = load_stl(FIXTURE_DIR / "triangle.stl")
+
+    assert isinstance(mesh, trimesh.Trimesh)
+    assert not mesh.is_empty
+    assert len(mesh.faces) == 1
+    assert len(mesh.vertices) == 3
+
+
+def test_load_stl_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.stl"
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        load_stl(missing)
+
+    assert str(missing) in str(exc_info.value)
+
+
+def test_load_stl_invalid_data(tmp_path: Path) -> None:
+    broken = tmp_path / "broken.stl"
+    broken.write_text("this is not a valid STL file", encoding="utf8")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_stl(broken)
+
+    assert str(broken) in str(exc_info.value)
+
+
+def test_load_stl_unsupported_format(tmp_path: Path) -> None:
+    other = tmp_path / "mesh.obj"
+    other.write_text("o example", encoding="utf8")
+
+    with pytest.raises(ValueError) as exc_info:
+        load_stl(other)
+
+    assert "Unsupported mesh format" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- add a `load_stl` helper that normalises STL loading errors and export it from the package
- ensure the CLI placeholder loads the mesh and reports basic geometry stats before running
- cover the loader with fixture-based tests for success, missing files, invalid data, and unsupported formats

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd9f05cef083229a913b4c8b92d708